### PR TITLE
Updated cmor output path to specification

### DIFF
--- a/src/CMORlight/control_cmor.ini_EUR11_ALADIN43_v1_CNRMESM21_r1i1p1f2_hist
+++ b/src/CMORlight/control_cmor.ini_EUR11_ALADIN43_v1_CNRMESM21_r1i1p1f2_hist
@@ -60,7 +60,7 @@ DirDerotated=work/output_derotated
 # "global_attr_list" must not be empty.
 #
 # Mandatory attributes are:
-# project_id,driving_model_id,experiment_id,driving_experiment_name,driving_model_ensemble_member,CORDEX_domain,institute_id,model_id,rcm_version_id,contact
+# project_id,mip_era,activity_id,driving_model_id,experiment_id,driving_experiment_name,driving_model_ensemble_member,CORDEX_domain,institute_id,model_id,rcm_version_id,contact
 #
 # All other attributes are optional.
 # Entries for listed attributes are defined in section 'settings' below; each attribute set in "global_attr_list" needs an entry/"value", otherwise the tool will stop.
@@ -68,7 +68,7 @@ DirDerotated=work/output_derotated
 # The attributes set in "global_attr_list" appear in the global attributes of the final file
 # The sequence of appearance in the file is determined by the sequence of their setting in this list
 
-global_attr_list=Conventions,conventionsURL,title,project_id,CORDEX_domain,driving_model_id,driving_experiment_name,experiment_id,driving_experiment,driving_model_ensemble_member,experiment,model_id,institute_id,institution,rcm_version_id,contact,comment,source,references
+global_attr_list=Conventions,conventionsURL,title,project_id,mip_era,activity_id,CORDEX_domain,driving_model_id,driving_experiment_name,experiment_id,driving_experiment,driving_model_ensemble_member,experiment,model_id,institute_id,institution,rcm_version_id,contact,comment,source,references
 #
 #HJP March 2019 End
 
@@ -218,6 +218,13 @@ var_list_fixed=orog,sftlf
 
 #project_id=CORDEX-FPSCONV
 project_id=CORDEX
+
+#mip_era: determines what cycle of CMIP defines experiment and data specifications (“CMIP6” is the only option)
+mip_era=CMIP6
+
+#activity_id: an identifier of different CORDEX activities such as dynamical downscaling (RCM), empirical-statistical
+#             downscaling (ESD), Flagship Pilot Study (FPS) and bias adjustment (Adjust).
+activity_id=RCM
 
 #driving model id: gcm_institute id + '-' + gcm_model_id; usually from http://cordex.dmi.dk/joomla/images/CORDEX/GCMModelName.txt
 driving_model_id=CNRM-ESM2-1

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -112,9 +112,10 @@ def create_outpath(res,var):
     '''
     Create and return the output path string from global attributes and dependent on resolution res and variable var
     '''
-    result = "%s/%s/%s/%s/%s/%s/%s/%s/%s/%s/%s" % \
+    result = "%s/%s/%s/%s/%s/%s/%s/%s/%s/%s/%s/%s" % \
                 (settings.Global_attributes["project_id"],
-                 settings.Global_attributes["product"],
+                 settings.Global_attributes["mip_era"],
+                 settings.Global_attributes["activity_id"],
                  settings.Global_attributes["CORDEX_domain"],
                  settings.Global_attributes["institute_id"],
                  settings.Global_attributes["driving_model_id"],


### PR DESCRIPTION
Changes for the cmorization step output path:

- Added two global attributes `mip_era` and `activity_id`.
- Changed the output path generated by `create_outpath(...)` to follow latest draft spec.

I added the attributes to `control_cmor.ini_EUR11_ALADIN43_v1_CNRMESM21_r1i1p1f2_hist`, but not `control_cmor.ini_CORDEX_EUR-11_CCLM`, which is only there for reference if I understand correctly. Let me know if the latter should be kept 'up to date' as well.