### PR TITLE
Specify source root dir as environment variable

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -19,7 +19,7 @@ simulation={simulation}
 DataPath={hclim_dir}/postprocess/HCLIM2CMOR/data
 
 #base path for DirConfig and DirLog; leave this empty if you want to specify absolute paths below
-BasePath=/home/sm_joalo/dev/repos/HCLIM2CMOR
+BasePath={hclim2cmor_dir}
 
 #Paths relative to BasePath
 #where the parameter table, the coordinates file and the vertices file are located

--- a/config/simulation_config.yml
+++ b/config/simulation_config.yml
@@ -9,6 +9,9 @@
 #   ...
 #   postprocess/
 #
+# Also, $HCLIM2CMORDIR must be defined and point to the folder containing
+# the HCLIM2CMOR source root.
+#
 # To run postprocessing for a simulation, configuration for the simulation
 # must be specified in this file.
 #

--- a/src/master_wrapper.py
+++ b/src/master_wrapper.py
@@ -58,6 +58,7 @@ def generate_control_cmor(simulation, var_list, simulation_config):
         format_dict = simulation_config.copy()
         format_dict["simulation"] = simulation
         format_dict["hclim_dir"] = os.environ["HCLIMDIR"]
+        format_dict["hclim2cmor_dir"] = os.environ["HCLIM2CMORDIR"]
         format_dict["var_list"] = var_list
         control_cmor = control_cmor_template.format(**format_dict)
 

--- a/src/settings.sh
+++ b/src/settings.sh
@@ -23,7 +23,7 @@ CONSTANT_FOLDER=${OVERRIDE_CONSTANT_FOLDER:-${CONSTANT_FOLDER}}
 
 #-------------------------------------------
 # Directory path settings
-export BASEDIR=${HOME}/dev/repos/HCLIM2CMOR    # directory where the scripts are placed 
+export BASEDIR=${HCLIM2CMORDIR}                              # directory where the HCLIM2CMOR source root is placed
 export DATADIR=${HCLIMDIR}/postprocess/HCLIM2CMOR/data       # directory where all the data will be placed (typically at /scratch/)
 
 # scripts directory


### PR DESCRIPTION
A small fix to avoid having to change the path to the source folder (i.e. the git clone folder) manually in two places after cloning. I added the requirement to define the `$HCLIM2CMORDIR` environment variable, which will be used for `$BASEDIR` in `src/settings.sh` and to set `BasePath` in the `config/control_cmor_template.ini` template file.

Does this sound reasonable? Please test and make sure it works on your end before merging.