### PR TITLE
fixing sbatch handling to submit all jobs at once (with dependencies)

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -128,7 +128,7 @@ alt_units=days since 1951-01-01 00:00:00
 extend_DirIn=False
 
 #Add version (default: current date; other values can be set in command line) to output path to not overwrite previously processed data
-add_version_to_outpath=False
+add_version_to_outpath=True
 
 # compression of netcdf file: requested by CORDEX
 nc_compress=True

--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -25,13 +25,13 @@ BasePath={hclim2cmor_dir}
 #where the parameter table, the coordinates file and the vertices file are located
 DirConfig=src/CMORlight/Config
 #for logging
-DirLog=logs/cmorlight
+DirLog=logs/cmorlight/{simulation}
 
 #Paths relative to Dataath:
 #Input directory for processing
 DirIn=work/input_CMORlight/{name_tag}
 #Output directory
-DirOut=OUT
+DirOut=OUT/{simulation}
 #directory for temporary files
 DirWork=temp
 #directory for derotated winds

--- a/config/simulation_config.yml
+++ b/config/simulation_config.yml
@@ -186,9 +186,9 @@ simulations:
     driving_experiment_id: "ssp126"
     driving_experiment: "update of RCP2.6 based on SSP1"
     driving_variant_label: "r1i1p1f1"
-    driving_institution_id: "DKRZ"
-    start_year: 1951
-    end_year: 2014
+    driving_institution_id: "MPI-M"
+    start_year: 2015
+    end_year: 2100
 
   "202315":
     name_tag: "EUR11_EUR11_ALADIN43_v1_MPIESM12HR_r1i1p1f1_ssp370"
@@ -196,9 +196,9 @@ simulations:
     driving_experiment_id: "ssp370"
     driving_experiment: "gap-filling scenario reaching 7.0 based on SSP3"
     driving_variant_label: "r1i1p1f1"
-    driving_institution_id: "DKRZ"
-    start_year: 1951
-    end_year: 2014
+    driving_institution_id: "MPI-M"
+    start_year: 2015
+    end_year: 2100
 
   "202316":
     name_tag: "EUR11_EUR11_ALADIN43_v1_ECE3Veg_r3i1p1f1_hist"
@@ -239,4 +239,3 @@ simulations:
     driving_institution_id: "NCC"
     start_year: 2015
     end_year: 2100
-

--- a/src/CMORlight/cmorlight.py
+++ b/src/CMORlight/cmorlight.py
@@ -363,8 +363,7 @@ def main():
     LOG_BASE = settings.DirLog
     if os.path.isdir(LOG_BASE) == False:
         print("Create logging directory: %s" % LOG_BASE)
-        if not os.path.isdir(LOG_BASE):
-            os.makedirs(LOG_BASE)
+        os.makedirs(LOG_BASE, exist_ok=True)
     #LOG_FILENAME = os.path.join(LOG_BASE,'CMORlight.')+config.get_sim_value('driving_source_id')+"_"+config.get_sim_value('driving_experiment_id')+"."
     LOG_FILENAME = os.path.join(LOG_BASE,'CMORlight.')+config.get_sim_value('driving_source_id')+"_"+config.get_sim_value('driving_experiment_id')+"_"+varlist[0]+"."
     logext = datetime.datetime.now().strftime("%d-%m-%Y")+'.log'
@@ -390,13 +389,11 @@ def main():
     # creating working directory if not existent
     if not os.path.isdir(settings.DirWork):
         log.debug("Working directory does not exist, creating: %s" % (settings.DirWork))
-        if not os.path.isdir(settings.DirWork):
-            os.makedirs(settings.DirWork)
+        os.makedirs(settings.DirWork, exist_ok=True)
 
     if not os.path.isdir(settings.DirOut):
         log.debug("Output directory does not exist, creating: %s" % (settings.DirOut))
-        if not os.path.isdir(settings.DirOut):
-            os.makedirs(settings.DirOut)
+        os.makedirs(settings.DirOut, exist_ok=True)
 
     if config.get_config_value('boolean','add_version_to_outpath'):
         settings.use_version = options.use_version

--- a/src/CMORlight/tools.py
+++ b/src/CMORlight/tools.py
@@ -393,7 +393,7 @@ def do_chunking(f_list,var,res,start_date, stop_date, outdir):
     # generate outpath with outfile and outdir
 
     if not os.path.isdir(outdir):
-        os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
     outpath = "%s/%s" % (outdir,outfile)
 
     # generate input filelist

--- a/src/settings.sh
+++ b/src/settings.sh
@@ -30,7 +30,7 @@ export DATADIR=${HCLIMDIR}/postprocess/HCLIM2CMOR/data       # directory where a
 SRCDIR=${BASEDIR}/src                 # directory where the post processing scripts are stored
 SRCDIR_POST=${BASEDIR}/src/hclim_post # directory where the subscripts are stored
 
-WORKDIR=${DATADIR}/work/post/${GCM}_${EXP} # work directory
+WORKDIR=${DATADIR}/work/post/${SIMULATION}_${GCM}_${EXP} # work directory
 LOGDIR=${DATADIR}/work/logs                # logging directory
 
 # input/output directories


### PR DESCRIPTION
I've made some changes/fixes, mainly in the `master_wrapper.py` script, please have a look to see if it makes sense to you:

In commit order:
1. Two fixes in simulation config.
2. I've added the simulation name to some intermediate and output folders, and modified directory creation a bit, because I ran simulations in parallel which ended up sharing folders, which resulted in corrupted data.
3. I changed the `add_version_to_outpath`setting in the control_cmor ini file to `True`, to get a version folder at the end of the output path. It's currently set to `latest`, but I'm adding it so that the path adheres to the drs.
4. I've refactored how sbatch jobs are created/submitted in `master_wrapper.py`. Before when running `master_wrapper` you had to keep the terminal/python process alive until the cmorization was completely finished. I've changed it so that all jobs are submitted at once, but the cmor and chunk jobs are dependent on the post jobs, so they will not be started until the previous step is finished. Now you can call the master wrapper script and let the jobs run by themselves until they are finished on the slurm machines :)

I also ran `black` python formatter on `master_wrapper.py`, which is why some changes are not really related to function, but style.
