### PR TITLE
Do not include dimension "nv" in cmorized output

### DIFF
--- a/config/control_cmor_template.ini
+++ b/config/control_cmor_template.ini
@@ -109,7 +109,7 @@ ZModelType=ZLevel
 cdo_nctype=nc4c
 
 #dimensions that should no be copied to output files
-varlist_reject=pressure,height_2m,height_10m,height_toa,soil1,soil1_bnds,height,plev,nb2,bnds,time_bnds
+varlist_reject=pressure,height_2m,height_10m,height_toa,soil1,soil1_bnds,height,plev,nb2,bnds,time_bnds,nv
 
 #attributes that should no be copied to output files
 attrlist_reject=par,lvt,lev,tri,FA_name,uvRelativeToGrid


### PR DESCRIPTION
Closes #80 

It seems only the fx vars have the `nv` dimension, I'm adding it to the exclusion list `varlist_reject`, which will prohibit the dimension to be added to any output.